### PR TITLE
在DataParser中提供一个Hook(虚方法)供继承类进行重写，从而实现对实体属性的自定义处理操作（比Formatters更加灵活）

### DIFF
--- a/src/DotnetSpider.Sample/samples/EntitySpider.cs
+++ b/src/DotnetSpider.Sample/samples/EntitySpider.cs
@@ -59,11 +59,12 @@ namespace DotnetSpider.Sample.samples
 
 		protected override async Task InitializeAsync(CancellationToken stoppingToken = default)
 		{
+			//AddDataFlow(new CnblogsParser()); //可通过继承默认的DataParser<T>并重写ProcessPropertyValue()方法，来实现对实体属性的自定义处理（比Formatters更加灵活）
 			AddDataFlow(new DataParser<CnblogsEntry>());
 			AddDataFlow(GetDefaultStorage());
 			await AddRequestsAsync(
 				new Request(
-					"https://news.cnblogs.com/n/page/1", new Dictionary<string, object> {{"网站", "博客园"}}));
+					"https://news.cnblogs.com/n/page/1", new Dictionary<string, object> { { "网站", "博客园" } }));
 		}
 
 		protected override SpiderId GenerateSpiderId()
@@ -75,13 +76,13 @@ namespace DotnetSpider.Sample.samples
 		[EntitySelector(Expression = ".//div[@class='news_block']", Type = SelectorType.XPath)]
 		[GlobalValueSelector(Expression = ".//a[@class='current']", Name = "类别", Type = SelectorType.XPath)]
 		[GlobalValueSelector(Expression = "//title", Name = "Title", Type = SelectorType.XPath)]
-		[FollowRequestSelector(Expressions = new[] {"//div[@class='pager']"})]
+		[FollowRequestSelector(Expressions = new[] { "//div[@class='pager']" })]
 		public class CnblogsEntry : EntityBase<CnblogsEntry>
 		{
 			protected override void Configure()
 			{
 				HasIndex(x => x.Title);
-				HasIndex(x => new {x.WebSite, x.Guid}, true);
+				HasIndex(x => new { x.WebSite, x.Guid }, true);
 			}
 
 			public int Id { get; set; }
@@ -117,6 +118,21 @@ namespace DotnetSpider.Sample.samples
 
 			[ValueSelector(Expression = "DATETIME", Type = SelectorType.Environment)]
 			public DateTime CreationTime { get; set; }
+		}
+
+		public class CnblogsParser : DataParser<CnblogsEntry>
+		{
+			public override string ProcessPropertyValue(string propertyName, string value)
+			{
+				switch (propertyName)
+				{
+					case "Title":
+						//可对任一实体属性执行自定义处理
+						return $"{value}_{DateTime.Now.Ticks}";
+					default:
+						return value;
+				}
+			}
 		}
 	}
 }

--- a/src/DotnetSpider/DataFlow/Parser/DataParser`.cs
+++ b/src/DotnetSpider/DataFlow/Parser/DataParser`.cs
@@ -30,46 +30,46 @@ namespace DotnetSpider.DataFlow.Parser
 					switch (followSelector.SelectorType)
 					{
 						case SelectorType.Css:
-						{
-							foreach (var expression in followSelector.Expressions)
 							{
-								AddFollowRequestQuerier(Selectors.Css(expression));
-							}
+								foreach (var expression in followSelector.Expressions)
+								{
+									AddFollowRequestQuerier(Selectors.Css(expression));
+								}
 
-							break;
-						}
+								break;
+							}
 						case SelectorType.Regex:
-						{
-							foreach (var expression in followSelector.Expressions)
 							{
-								AddFollowRequestQuerier(Selectors.Regex(expression));
-							}
+								foreach (var expression in followSelector.Expressions)
+								{
+									AddFollowRequestQuerier(Selectors.Regex(expression));
+								}
 
-							break;
-						}
+								break;
+							}
 						case SelectorType.XPath:
-						{
-							foreach (var expression in followSelector.Expressions)
 							{
-								AddFollowRequestQuerier(Selectors.XPath(expression));
-							}
+								foreach (var expression in followSelector.Expressions)
+								{
+									AddFollowRequestQuerier(Selectors.XPath(expression));
+								}
 
-							break;
-						}
+								break;
+							}
 						case SelectorType.Environment:
-						{
-							Logger.LogWarning("SelectorType of follow selector is not supported");
-							break;
-						}
-						case SelectorType.JsonPath:
-						{
-							foreach (var expression in followSelector.Expressions)
 							{
-								AddFollowRequestQuerier(Selectors.JsonPath(expression));
+								Logger.LogWarning("SelectorType of follow selector is not supported");
+								break;
 							}
+						case SelectorType.JsonPath:
+							{
+								foreach (var expression in followSelector.Expressions)
+								{
+									AddFollowRequestQuerier(Selectors.JsonPath(expression));
+								}
 
-							break;
-						}
+								break;
+							}
 					}
 
 					foreach (var pattern in followSelector.Patterns)
@@ -85,6 +85,11 @@ namespace DotnetSpider.DataFlow.Parser
 			}
 
 			return Task.CompletedTask;
+		}
+
+		public virtual string ProcessPropertyValue(string propertyName, string value)
+		{
+			return value;
 		}
 
 		protected virtual TEntity ConfigureDataObject(TEntity t)
@@ -219,6 +224,8 @@ namespace DotnetSpider.DataFlow.Parser
 					}
 				}
 
+				value = ProcessPropertyValue(field.PropertyInfo.Name, value);
+
 				var newValue = value == null ? null : Convert.ChangeType(value, field.PropertyInfo.PropertyType);
 				if (newValue == null && field.NotNull)
 				{
@@ -240,60 +247,60 @@ namespace DotnetSpider.DataFlow.Parser
 			switch (field.Expression?.ToUpper())
 			{
 				case Const.EnvironmentNames.EntityIndex:
-				{
-					value = index.ToString();
-					break;
-				}
+					{
+						value = index.ToString();
+						break;
+					}
 
 				case Const.EnvironmentNames.Guid:
-				{
-					value = Guid.NewGuid().ToString();
-					break;
-				}
+					{
+						value = Guid.NewGuid().ToString();
+						break;
+					}
 
 				case Const.EnvironmentNames.Date:
 				case Const.EnvironmentNames.Today:
-				{
-					value = DateTimeOffset.Now.Date.ToString("yyyy-MM-dd");
-					break;
-				}
+					{
+						value = DateTimeOffset.Now.Date.ToString("yyyy-MM-dd");
+						break;
+					}
 
 				case Const.EnvironmentNames.Datetime:
 				case Const.EnvironmentNames.Now:
-				{
-					value = DateTimeOffset.Now.ToString("yyyy-MM-dd HH:mm:ss");
-					break;
-				}
+					{
+						value = DateTimeOffset.Now.ToString("yyyy-MM-dd HH:mm:ss");
+						break;
+					}
 
 				case Const.EnvironmentNames.Month:
-				{
-					value = DateTimeHelper.FirstDayOfMonth.ToString("yyyy-MM-dd");
-					break;
-				}
+					{
+						value = DateTimeHelper.FirstDayOfMonth.ToString("yyyy-MM-dd");
+						break;
+					}
 
 				case Const.EnvironmentNames.Monday:
-				{
-					value = DateTimeHelper.Monday.ToString("yyyy-MM-dd");
-					break;
-				}
+					{
+						value = DateTimeHelper.Monday.ToString("yyyy-MM-dd");
+						break;
+					}
 
 				case Const.EnvironmentNames.SpiderId:
-				{
-					value = context.Request.Owner;
-					break;
-				}
+					{
+						value = context.Request.Owner;
+						break;
+					}
 
 				case Const.EnvironmentNames.RequestHash:
-				{
-					value = context.Request.Hash;
-					break;
-				}
+					{
+						value = context.Request.Hash;
+						break;
+					}
 				default:
-				{
-					value = string.IsNullOrWhiteSpace(field.Expression) ? null :
-						properties.ContainsKey(field.Expression) ? properties[field.Expression]?.ToString() : null;
-					break;
-				}
+					{
+						value = string.IsNullOrWhiteSpace(field.Expression) ? null :
+							properties.ContainsKey(field.Expression) ? properties[field.Expression]?.ToString() : null;
+						break;
+					}
 			}
 
 			return value;


### PR DESCRIPTION
如题，现有的Formatters因受限于Attribute parameter type的限制不能进行灵活的自定义处理操作，在DataParser中提供一个Hook能很好的解决这个问题。

使用场景：比如我想自定义生成ID属性，规则是属性值+时间戳