### PR TITLE
在DataParser中提供一个Hook虚方法供继承类进行重写，从而实现对实体属性的自定义处理（比Formatters更加灵活）

### DIFF
--- a/src/DotnetSpider.Sample/samples/EntitySpider.cs
+++ b/src/DotnetSpider.Sample/samples/EntitySpider.cs
@@ -59,6 +59,7 @@ namespace DotnetSpider.Sample.samples
 
 		protected override async Task InitializeAsync(CancellationToken stoppingToken = default)
 		{
+			//AddDataFlow(new CnblogsParser()); //可通过继承默认的DataParser<T>并重写ProcessPropertyValue()方法，来实现对实体属性的自定义处理（比Formatters更加灵活）
 			AddDataFlow(new DataParser<CnblogsEntry>());
 			AddDataFlow(GetDefaultStorage());
 			await AddRequestsAsync(
@@ -117,6 +118,21 @@ namespace DotnetSpider.Sample.samples
 
 			[ValueSelector(Expression = "DATETIME", Type = SelectorType.Environment)]
 			public DateTime CreationTime { get; set; }
+		}
+
+		public class CnblogsParser : DataParser<CnblogsEntry>
+		{
+			public override string ProcessPropertyValue(string propertyName, string value)
+			{
+				switch (propertyName)
+				{
+					case "Title":
+						//可对任一实体属性执行自定义处理
+						return $"{value}_{DateTime.Now.Ticks}";
+					default:
+						return value;
+				}
+			}
 		}
 	}
 }

--- a/src/DotnetSpider/DataFlow/Parser/DataParser`.cs
+++ b/src/DotnetSpider/DataFlow/Parser/DataParser`.cs
@@ -87,6 +87,11 @@ namespace DotnetSpider.DataFlow.Parser
 			return Task.CompletedTask;
 		}
 
+		public virtual string ProcessPropertyValue(string propertyName, string value)
+		{
+			return value;
+		}
+
 		protected virtual TEntity ConfigureDataObject(TEntity t)
 		{
 			return t;
@@ -218,6 +223,8 @@ namespace DotnetSpider.DataFlow.Parser
 						}
 					}
 				}
+
+				value = ProcessPropertyValue(field.PropertyInfo.Name, value);
 
 				var newValue = value == null ? null : Convert.ChangeType(value, field.PropertyInfo.PropertyType);
 				if (newValue == null && field.NotNull)


### PR DESCRIPTION
如题，现有的Formatters因受限于Attribute parameter type的限制不能进行灵活的自定义处理操作（传入attribute的值只能是primitive类型），在DataParser中提供一个Hook能很好的解决这个问题。

使用场景：比如我想自定义生成ID属性，规则是属性值+时间戳